### PR TITLE
Youtube Data API v2 has been shutdown

### DIFF
--- a/lib/omniauth/strategies/youtube_oauth2.rb
+++ b/lib/omniauth/strategies/youtube_oauth2.rb
@@ -35,7 +35,7 @@ module OmniAuth
         end
       end
 
-      uid { user['author'][0]["yt$userId"]["$t"] }
+      uid { user['id'] }
 
       info do
         prune!({
@@ -58,11 +58,11 @@ module OmniAuth
       end
 
       def user
-        user_hash['entry']
+        user_hash['items'][0]
       end
 
       def user_hash
-        @user_hash ||= MultiJson.decode(access_token.get("http://gdata.youtube.com/feeds/api/users/default?v=2&alt=json").body)
+        @user_hash ||= MultiJson.decode(access_token.get("https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true").body)
       end
 
       private

--- a/spec/omniauth/strategies/youtube_oauth2_spec.rb
+++ b/spec/omniauth/strategies/youtube_oauth2_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'omniauth-youtube-oauth2'
 
-describe OmniAuth::Strategies::YoutubeOauth2 do
+describe OmniAuth::Strategies::Youtube do
   def app; lambda{|env| [200, {}, ["Hello."]]} end
 
   before :each do
@@ -18,7 +18,7 @@ describe OmniAuth::Strategies::YoutubeOauth2 do
 
   subject do
     args = ['appid', 'secret', @options || {}].compact
-    OmniAuth::Strategies::YoutubeOauth2.new(app, *args).tap do |strategy|
+    OmniAuth::Strategies::Youtube.new(app, *args).tap do |strategy|
       strategy.stub(:request) { @request }
     end
   end
@@ -41,7 +41,7 @@ describe OmniAuth::Strategies::YoutubeOauth2 do
 
   describe '#callback_path' do
     it 'has the correct callback path' do
-      subject.callback_path.should eq('/auth/youtube-oauth2/callback')
+      subject.callback_path.should eq('/auth/youtube/callback')
     end
   end
 


### PR DESCRIPTION
See http://youtube-eng.blogspot.co.at/2015/04/bye-bye-youtube-data-api-v2.html for more info.
Adapted the `user_hash` retrieval to use the v3 api.

Also had to adapt the array accessing -> api response different than v2.
